### PR TITLE
start session before unsetting it

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -1,6 +1,11 @@
 <?php
 require 'connect.php';
 
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
 session_unset();
 session_destroy();
 


### PR DESCRIPTION
## Problem
The logout functionality was not properly destroying sessions because `session_start()` was not called before attempting to unset and destroy the session.

## Solution
Added `session_start()` check (using `session_status() === PHP_SESSION_NONE`) before calling `session_unset()` and `session_destroy()`, following the same pattern used in `profile.php`.

## Changes
- Added session status check and session_start() call in `logout.php`

## Testing
- [ ] Verified that logout properly destroys the session
- [ ] Confirmed user is redirected to login page after logout
- [ ] Verified user cannot access protected pages after logout